### PR TITLE
Replace FTP Server References with Unidata Nexus Server

### DIFF
--- a/Dockerfile.tdm
+++ b/Dockerfile.tdm
@@ -39,16 +39,14 @@ RUN mkdir -p $TDM_HOME
 
 WORKDIR $TDM_HOME
 
-ENV TDS_MAJOR_VERSION 4.6
-ENV TDS_MINOR_VERSION 4.6.6
-ENV TDM_VERSION 4.6
+ENV TDM_VERSION 4.6.6
 
 ###
 # Grab the TDM
 ###
 
 RUN curl -SL \
-    ftp://ftp.unidata.ucar.edu/pub/thredds/${TDS_MAJOR_VERSION}/${TDS_MINOR_VERSION}/tdm-${TDM_VERSION}.jar \
+    https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/${TDM_VERSION}/tdmFat-${TDM_VERSION}.jar \
     -o tdm-${TDM_VERSION}.jar
 
 ###

--- a/README.md
+++ b/README.md
@@ -220,6 +220,6 @@ Until `5.0`, the TDM lacks configurability with respect to the location of log f
 
 For example, you can get the `tdm.jar`:
 
-    curl -SL ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/4.6.6/tdm-4.6.jar -o tdm-4.6.jar
+    curl -SL  https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/4.6.6/tdmFat-4.6.6.jar -o tdm.jar
 
 The `tdm.sh` script can be found within this repository. Make sure the `tdm.sh` script is executable by the container.


### PR DESCRIPTION
Closes #42 

Replacing FTP server references with Unidata Nexus server according @lesserwhirls in #34.