### PR TITLE
redoing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,12 @@ sudo: required
 services:
   - docker
 
-env:
-  DOCKER_COMPOSE_VERSION: 1.5.2
-
 before_install:
   - docker build -t unidata/thredds-docker:latest .
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
+  - docker run --name thredds -v `pwd`/.travis:/travis -d -p 8080:8080 unidata/thredds-docker:latest
+  - curl -o /dev/null http://127.0.0.1:8080/thredds/catalog.html || true
+  # Give chance for TDS to fire up
+  - sleep 300
 
 script:
-  - docker-compose up -d thredds-quickstart
-
-after_script:
-  - docker ps
-  - curl http://localhost:80/thredds/catalog.html
+  - ./.travis/test.sh

--- a/.travis/expected.html
+++ b/.travis/expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'
+        'http://www.w3.org/TR/html4/loose.dtd'>
+<html>
+<head>
+<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>TdsStaticCatalog http://127.0.0.1:8080/thredds/catalog.html</title>
+<link rel='stylesheet' href='/thredds/tdsCat.css' type='text/css' >
+</head>
+<body><h1><img src='/thredds/threddsIcon.gif' alt='THREDDS' align='left' valign='top'>
+Catalog http://127.0.0.1:8080/thredds/catalog.html</h1><HR size='1' noshade='noshade'><table width='100%' cellspacing='0' cellpadding='5' align='center'>
+<tr>
+<th align='left'><font size='+1'>Dataset</font></th>
+<th align='center'><font size='+1'>Size</font></th>
+<th align='right'><font size='+1'>Last Modified</font></th>
+</tr><tr>
+<td align='left'>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href='catalog.html?dataset=testDataset'><tt>Test Single Dataset</tt></a></td>
+<td align='right'><tt>&nbsp;</tt></td>
+<td align='right'><tt>--</tt></td>
+</tr>
+<tr bgcolor='#eeeeee'>
+<td align='left'>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href='catalog.html?dataset=testDataset2'><tt>Test Single Dataset 2</tt></a></td>
+<td align='right'><tt>&nbsp;</tt></td>
+<td align='right'><tt>--</tt></td>
+</tr>
+<tr>
+<td align='left'>&nbsp;&nbsp;&nbsp;&nbsp;
+<img src='/thredds/folder.gif' alt='Folder'> &nbsp;<a href='/thredds/catalog/testAll/catalog.html'><tt>Test all files in a directory/</tt></a></td>
+<td align='right'><tt>&nbsp;</tt></td>
+<td align='right'><tt>--</tt></td>
+</tr>
+<tr bgcolor='#eeeeee'>
+<td align='left'>&nbsp;&nbsp;&nbsp;&nbsp;
+<img src='/thredds/folder.gif' alt='Folder'> &nbsp;<a href='enhancedCatalog.html'><tt>Test Enhanced Catalog/</tt></a></td>
+<td align='right'><tt>&nbsp;</tt></td>
+<td align='right'><tt>--</tt></td>
+</tr>
+</table>
+<HR size='1' noshade='noshade'><h3><a href='/thredds/catalog.html'>THREDDS</a> at <a href='http://www.my.site/'>My Group</a> see <a href='/thredds/serverInfo.html'> Info </a><br>
+THREDDS Data Server [Version 4.6.6 - 2016-06-13T15:13:41-0600] <a href='http://www.unidata.ucar.edu/software/thredds/current/tds/reference/index.html'> Documentation</a></h3>
+</body>
+</html>

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+curl -o ./.travis/actual.html http://127.0.0.1:8080/thredds/catalog.html
+
+diff ./.travis/expected.html ./.travis/actual.html
+
+cmp ./.travis/expected.html ./.travis/actual.html
+


### PR DESCRIPTION
closes #75 #39. This travis configuration tests the out-of-the-box THREDDS catalog: http://127.0.0.1:8080/thredds/catalog.html against an expected result. Also, it does away with `docker-compose` in the `.travis.yml`.