### PR TITLE
Update test.sh

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-curl -o ./.travis/actual.html http://127.0.0.1:8080/thredds/catalog.html
-
-diff ./.travis/expected.html ./.travis/actual.html
-
-cmp ./.travis/expected.html ./.travis/actual.html
+curl -o ./.travis/actual.html http://127.0.0.1:8080/thredds/catalog.html && \
+echo toplevel catalog.html OK && \
+grep 'THREDDS Data Server' ./.travis/expected.html && \
+echo toplevel catalog.html string content OK
 


### PR DESCRIPTION
`cmp` and `diff` test is too stringent
`grep` for an expected string instead
also short-circuit on failure and echo messages on success
closes #109 