### PR TITLE
Update 5.0 SNAPSHOT artifact from Oct 26 to Dec 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN export CPPFLAGS=-I/usr/local/include \
 ###
 
 ENV TDS_VERSION 5.0.0
-ENV TDS_SNAPSHOT_VERSION ${TDS_VERSION}-20161026.011301-32
+ENV TDS_SNAPSHOT_VERSION ${TDS_VERSION}-20161213.124401-60
 ENV THREDDS_WAR_URL https://artifacts.unidata.ucar.edu/content/repositories/unidata-snapshots/edu/ucar/tds/${TDS_VERSION}-SNAPSHOT/tds-${TDS_SNAPSHOT_VERSION}.war
 
 RUN curl -fSL "${THREDDS_WAR_URL}" -o thredds.war


### PR DESCRIPTION
I'm hoping that this version contains the fix that @lesserwhirls mentioned during the December 2 Thredds Steering Team Meeting:  That datasets containing `location` will now work with ncWMS.