### PR TITLE
Updates to both TDM and THREDDS and Compose config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## Unreleased - 2017-04-26
+### Added
+- Updated the Docker compose configuration to version 3
+- Set up Docker volumes for the Docker containers in the Docker compose config
+- Set up a Docker network in Docker compose that puts both containers (TDM & THREDDS)
+  onto it
+- Moved a lot of the configuration variables from Dockerfiles and Docker compose
+  configuration file into an external environments file
+- Removed the thredds-quickstart service from the compose configuration as it just
+  duplicates the docker-production service
+- Updated the Java startup options to move some hard coded values to environment
+  variables
+- Added a health check to the THREDDS Docker configuration that tests for a healthy
+  response from the THREDDS server
+- Removed the shell script that gets executed for the TDM Docker container. The
+  command is now executed inline
+
 ## 4.6.10 - 2017-04-20
 ### Added
 - 4.6.10 release of the Unidata TDS wrapped in a Docker container

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,10 @@ WORKDIR ${CATALINA_HOME}
 
 RUN rm -rf /downloads
 
+ENV THREDDS_XMX_SIZE 4g
+ENV THREDDS_XMS_SIZE 4g
+ENV TDM_CONTENT_ROOT_PATH /usr/local/tomcat/content
+
 ###
 # Inherited from parent container
 ###
@@ -139,3 +143,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 ###
 
 CMD ["catalina.sh", "run"]
+
+HEALTHCHECK --interval=60s --timeout=3s \
+	CMD curl --fail 'http://localhost:8080/thredds/catalog.html' || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /downloads
 
 ###
 # Installing netcdf-c library according to:
-# http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/reference/netcdf4Clibrary.html 
+# http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/reference/netcdf4Clibrary.html
 ###
 
 ENV LD_LIBRARY_PATH /usr/local/lib:${LD_LIBRARY_PATH}
@@ -107,7 +107,7 @@ COPY files/javaopts.sh $CATALINA_HOME/bin/javaopts.sh
 RUN chmod 755 $CATALINA_HOME/bin/*.sh
 
 ###
-# Creating .systemPrefs directory according to 
+# Creating .systemPrefs directory according to
 # http://www.unidata.ucar.edu/software/thredds/current/tds/faq.html#javaUtilPrefs
 # and as defined in the files/javaopts.sh file
 ###

--- a/README.md
+++ b/README.md
@@ -17,6 +17,61 @@ A containerized [THREDDS Data Server](http://www.unidata.ucar.edu/software/thred
 
     docker run -d -p 80:8080 unidata/thredds-docker
 
+## `docker-machine`
+
+To run the THREDDS Docker container on Docker machine, one special configuration element that is required is to create the initial VM with at least 4G of RAM. In the following example, a VirtualBox Docker machine instance with 6G of RAM is created:
+
+```
+$ docker-machine create --virtualbox-memory "6144" thredds
+Running pre-create checks...
+Creating machine...
+(thredds) Copying ~/.docker/machine/cache/boot2docker.iso to ~/.docker/machine/machines/thredds/boot2docker.iso...
+(thredds) Creating VirtualBox VM...
+(thredds) Creating SSH key...
+(thredds) Starting the VM...
+(thredds) Check network to re-create if needed...
+(thredds) Waiting for an IP...
+Waiting for machine to be running, this may take a few minutes...
+Detecting operating system of created instance...
+Waiting for SSH to be available...
+Detecting the provisioner...
+Provisioning with boot2docker...
+Copying certs to the local machine directory...
+Copying certs to the remote machine...
+Setting Docker configuration on the remote daemon...
+Checking connection to Docker...
+Docker is up and running!
+To see how to connect your Docker Client to the Docker Engine running on this virtual machine, run: docker-machine env thredds
+
+$ eval $(docker-machine env thredds)
+
+$ docker-compose up thredds-production
+Creating volume "threddsdocker_thredds-volume" with default driver
+Creating thredds
+Attaching to thredds
+thredds               | 26-Apr-2017 15:25:18.907 WARNING [main] org.apache.catalina.startup.SetAllPropertiesRule.begin [SetAllPropertiesRule]{Server/Service/Connector} Setting property 'server' to 'Apache' did not find a matching property.
+[...]
+thredds               | 26-Apr-2017 15:25:45.356 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in 26113 ms
+```
+
+At this point, the THREDDS Docker container is up and running. You should be able to open another shell and test via curl:
+```
+$ curl http://`docker-machine ip thredds`/thredds/catalog.html
+<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'
+        'http://www.w3.org/TR/html4/loose.dtd'>
+<html>
+<head>
+<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>TdsStaticCatalog http://192.168.99.100/thredds/catalog.html</title>
+<link rel='stylesheet' href='/thredds/tdsCat.css' type='text/css' >
+</head>
+[...]
+```
+
+You can also open in a browser. First find out the IP of your Docker machine by issuing `docker-machine ip thredds`
+
+If the IP were 192.168.99.100, you can navigate your browser to http://192.168.99.100/thredds/catalog.html to test
+
+
 ## `docker-compose`
 
 To run the THREDDS Docker container, beyond a basic Docker setup, we recommend installing [docker-compose](https://docs.docker.com/compose/). `docker-compose` serves two purposes:
@@ -93,7 +148,7 @@ to mount individual files, you should also mount a cache directory.
     - /path/to/your/thredds/logs/:/usr/local/tomcat/content/thredds/logs/
     - /path/to/your/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
     - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
-    - /path/to/your/data/directory1:/path/to/your/data/directory1 
+    - /path/to/your/data/directory1:/path/to/your/data/directory1
     - /path/to/your/data/directory2:/path/to/your/data/directory2
 ```
 
@@ -118,7 +173,7 @@ By default, Tomcat will start with [two user accounts](https://github.com/Unidat
  * Directory containing TDS configuration files (e.g. `threddsConfig.xml`, `wmsConfig.xml` and THREDDS catalog `.xml` files) in `/usr/local/tomcat/content/thredds`
  * Folders containing NetCDF and other data files read by the TDS in `/data1` and `/data2`
  * Tomcat users configured in `/usr/local/tomcat/conf/tomcat-users.xml`
- 
+
 Then you could issue this command to fire up the new Docker TDS container (remember to stop the old TDS first):
 
     docker-compose stop thredds-production
@@ -182,7 +237,7 @@ At this point we are done setting up the TDS with docker. To navigate to this in
 
 ## TDM
 
-The THREDDS Data Manager or TDM is an application that works in conjunction with the TDS. It creates indexes for GRIB data in a background process, and notifies the TDS via port `8443` when data have been updated or changed. See [here](https://www.unidata.ucar.edu/software/thredds/current/tds/reference/collections/TDM.html) to learn more about the TDM. 
+The THREDDS Data Manager or TDM is an application that works in conjunction with the TDS. It creates indexes for GRIB data in a background process, and notifies the TDS via port `8443` when data have been updated or changed. See [here](https://www.unidata.ucar.edu/software/thredds/current/tds/reference/collections/TDM.html) to learn more about the TDM.
 
 ### Versions
 

--- a/compose.env
+++ b/compose.env
@@ -1,0 +1,30 @@
+TDM_CONTENT_ROOT_PATH=/usr/local/tomcat/content
+
+### THREDDS
+
+THREDDS_XMX_SIZE=4g
+THREDDS_XMS_SIZE=4g
+
+#### TDM
+# If you send notifications, the TDS will authenticate using this user name and
+# password. If you do not include this option, you will be prompted for the
+# password on startup, and the user name will be "tdm".
+TDM_USER=tdm
+
+# This is the password that ships with this project in files/tomcat-users.xml
+# Update this if you are not using the default configuration or are using an
+# external THREDDS server
+TDM_PW=1a8755ca18bea68fa43e2fa2d5d89fde446d3151
+
+# This is the endpoint of your THREDDS server. By default, when using Docker Compose,
+# 'thredds' is the hostname for the THREDDS Docker container on the named 'thredds-network'.
+# All other containers running on this network will translate the 'thredds' hostname
+# to the IP address of the running THREDDS container
+# That trailing slash is important
+TDS_HOST=http://thredds/
+
+# Set the log4j logging level
+LOG_LEVEL=INFO
+
+# The amoiunt of Xmx memory to allocate to the TDM run
+TDM_XMX_SIZE=6g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,51 +3,51 @@ version: '3'
 
 volumes:
   thredds-volume:
+  tdm-volume:
+
+networks:
+  thredds-network:
 
 services:
-  ###
-  # THREDDS Quickstart
-  ###
-  thredds-quickstart:
-    image: unidata/thredds-docker:4.6.10
-    ports:
-      - "80:8080"
-      - "443:8443"
-      - "8443:8443"
-
-  ###
-  # THREDDS Production
-  ###
-
   thredds-production:
     image: unidata/thredds-docker:4.6.10
+    container_name: thredds
     ports:
       - "80:8080"
       - "8080:8080"
       - "443:8443"
       - "8443:8443"
-    container_name: thredds
+    networks:
+      thredds-network:
+        aliases:
+          - thredds
     volumes:
-      - thredds-volume:/usr/local/tomcat/logs/
-      - thredds-volume:/usr/local/tomcat/content/thredds/logs/
-      - thredds-volume:/usr/local/tomcat/content/thredds
+      - thredds-volume:/usr/local/tomcat/content
+      # - thredds-volume:/usr/local/tomcat/content/thredds/logs/
+      # - thredds-volume:/usr/local/tomcat/content/thredds
       # - /path/to/your/local/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
-
-  ###
-  # TDM
-  ###
+    env_file:
+      # Set an env var on the host for THREDDS_COMPOSE_ENV_LOCAL if you want to use
+      # your own env file. For example, if you have a compose_local.env file,
+      # set THREDDS_COMPOSE_ENV_LOCAL=_local before running docker-compose
+      - "compose${THREDDS_COMPOSE_ENV_LOCAL}.env"
 
   tdm:
     image: unidata/thredds-docker:tdm-4.6
     container_name: tdm
+    networks:
+      thredds-network:
+        aliases:
+          - tdm
     volumes:
-      - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
-      - /path/to/your/data/directory1:/path/to/your/data/directory1
+      - tdm-volume:/usr/local/tomcat/content
+      # - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
+      # - /path/to/your/data/directory1:/path/to/your/data/directory1
       # TDM logging non-configurable until 5.0 so you'll need tdm.sh and
       # tdm.jar if you want to log outside the container :-(
-      - /path/to/your/tdm/logs:/usr/local/tomcat/content/tdm/
-    environment:
-      # change the password
-      - TDM_PW=CHANGEME!
-      # that trailing slash is important
-      - TDS_HOST=http://thredds.yourhost.net/
+      # - /path/to/your/tdm/logs:/usr/local/tomcat/content/tdm/
+    env_file:
+      # Set an env var on the host for THREDDS_COMPOSE_ENV_LOCAL if you want to use
+      # your own env file. For example, if you have a compose_local.env file,
+      # set THREDDS_COMPOSE_ENV_LOCAL=_local before running docker-compose
+      - "compose${THREDDS_COMPOSE_ENV_LOCAL}.env"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,47 +1,51 @@
-###
-# THREDDS Quickstart
-###
-thredds-quickstart:
-  image: unidata/thredds-docker:4.6.10
-  ports:
-    - "80:8080"
-    - "443:8443"
-    - "8443:8443"
+---
+version: '3'
 
-###
-# THREDDS Production
-###
+services:
+  ###
+  # THREDDS Quickstart
+  ###
+  thredds-quickstart:
+    image: unidata/thredds-docker:4.6.10
+    ports:
+      - "80:8080"
+      - "443:8443"
+      - "8443:8443"
 
-thredds-production:
-  image: unidata/thredds-docker:4.6.10
-  ports:
-    - "80:8080"
-    - "443:8443"
-    - "8443:8443"
-  container_name: thredds
-  volumes:
-    - /path/to/your/tomcat/logs/:/usr/local/tomcat/logs/
-    - /path/to/your/thredds/logs/:/usr/local/tomcat/content/thredds/logs/
-    - /path/to/your/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
-    - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
-    - /path/to/your/data/directory1:/path/to/your/data/directory1 
-    - /path/to/your/data/directory2:/path/to/your/data/directory2
+  ###
+  # THREDDS Production
+  ###
 
-###
-# TDM
-###
+  thredds-production:
+    image: unidata/thredds-docker:4.6.10
+    ports:
+      - "80:8080"
+      - "443:8443"
+      - "8443:8443"
+    container_name: thredds
+    volumes:
+      - /path/to/your/tomcat/logs/:/usr/local/tomcat/logs/
+      - /path/to/your/thredds/logs/:/usr/local/tomcat/content/thredds/logs/
+      - /path/to/your/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
+      - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
+      - /path/to/your/data/directory1:/path/to/your/data/directory1
+      - /path/to/your/data/directory2:/path/to/your/data/directory2
 
-tdm:
-  image: unidata/thredds-docker:tdm-4.6
-  container_name: tdm
-  volumes:
-    - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
-    - /path/to/your/data/directory1:/path/to/your/data/directory1
-    # TDM logging non-configurable until 5.0 so you'll need tdm.sh and
-    # tdm.jar if you want to log outside the container :-(
-    - /path/to/your/tdm/logs:/usr/local/tomcat/content/tdm/
-  environment:
-    # change the password
-    - TDM_PW=CHANGEME!
-    # that trailing slash is important
-    - TDS_HOST=http://thredds.yourhost.net/
+  ###
+  # TDM
+  ###
+
+  tdm:
+    image: unidata/thredds-docker:tdm-4.6
+    container_name: tdm
+    volumes:
+      - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
+      - /path/to/your/data/directory1:/path/to/your/data/directory1
+      # TDM logging non-configurable until 5.0 so you'll need tdm.sh and
+      # tdm.jar if you want to log outside the container :-(
+      - /path/to/your/tdm/logs:/usr/local/tomcat/content/tdm/
+    environment:
+      # change the password
+      - TDM_PW=CHANGEME!
+      # that trailing slash is important
+      - TDS_HOST=http://thredds.yourhost.net/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 ---
 version: '3'
 
+volumes:
+  thredds-volume:
+
 services:
   ###
   # THREDDS Quickstart
@@ -20,16 +23,15 @@ services:
     image: unidata/thredds-docker:4.6.10
     ports:
       - "80:8080"
+      - "8080:8080"
       - "443:8443"
       - "8443:8443"
     container_name: thredds
     volumes:
-      - /path/to/your/tomcat/logs/:/usr/local/tomcat/logs/
-      - /path/to/your/thredds/logs/:/usr/local/tomcat/content/thredds/logs/
-      - /path/to/your/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
-      - /path/to/your/thredds/directory:/usr/local/tomcat/content/thredds
-      - /path/to/your/data/directory1:/path/to/your/data/directory1
-      - /path/to/your/data/directory2:/path/to/your/data/directory2
+      - thredds-volume:/usr/local/tomcat/logs/
+      - thredds-volume:/usr/local/tomcat/content/thredds/logs/
+      - thredds-volume:/usr/local/tomcat/content/thredds
+      # - /path/to/your/local/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
 
   ###
   # TDM

--- a/files/javaopts.sh
+++ b/files/javaopts.sh
@@ -8,10 +8,10 @@
 # Choosing a JAVA_PREFS_SYSTEM_ROOT directory location that will likely live
 # inside the container.
 
-NORMAL="-server -d64 -Xms4G -Xmx4G"
+NORMAL="-server -d64 -Xms${THREDDS_XMS_SIZE} -Xmx${THREDDS_XMX_SIZE}"
 HEAP_DUMP="-XX:+HeapDumpOnOutOfMemoryError"
 HEADLESS="-Djava.awt.headless=true"
-CONTENT_ROOT="-Dtds.content.root.path=$CATALINA_HOME/content"
+CONTENT_ROOT="-Dtds.content.root.path=${TDM_CONTENT_ROOT_PATH}"
 JAVA_PREFS_SYSTEM_ROOT="-Djava.util.prefs.systemRoot=$CATALINA_HOME/javaUtilPrefs -Djava.util.prefs.userRoot=$CATALINA_HOME/javaUtilPrefs"
 
 JAVA_OPTS="$JAVA_OPTS $CONTENT_ROOT/ $JAVA_PREFS_SYSTEM_ROOT $NORMAL $HEAP_DUMP $HEADLESS"

--- a/tdm/Dockerfile
+++ b/tdm/Dockerfile
@@ -47,14 +47,6 @@ RUN curl -SL \
     -o tdm.jar
 
 ###
-# Copy the TDM executable inside the container
-###
-
-COPY tdm.sh $TDM_HOME
-
-RUN chmod +x tdm.sh
-
-###
 # Change owner of tomcat directory to user and group tomcat
 ###
 
@@ -70,4 +62,12 @@ USER tomcat
 # TDS Command
 ###
 
-CMD $TDM_HOME/tdm.sh
+ENV TDM_XMX_SIZE 6g
+ENV TDM_CONTENT_ROOT_PATH /usr/local/tomcat/content
+ENV TDM_USER tdm
+ENV TDS_HOST http://thredds/
+ENV LOG_LEVEL info
+
+CMD java -jar -d64 -Xmx${TDM_XMX_SIZE} -DbbTdm=1 -Dtds.content.root.path=$TDM_CONTENT_ROOT_PATH \
+      $TDM_HOME/tdm.jar -nthreads 1 -cred $TDM_USER:$TDM_PW -tds "$TDS_HOST" \
+			-log $LOG_LEVEL

--- a/tdm/tdm.sh
+++ b/tdm/tdm.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-java -jar -d64 -Xmx6g -DbbTdm=1 -Dtds.content.root.path=$HOME/content \
-      $TDM_HOME/tdm.jar -nthreads 1 -cred \
-      tdm:$TDM_PW -tds $TDS_HOST


### PR DESCRIPTION
Note that inn order for the compose configuration changes to make sense, the available Docker containers would need to have a new version cut after being built and the Compose image tags for both containers would need to be increments to point to those.