### PR TITLE
unidata/thredds-docker:4.6.12-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A containerized [THREDDS Data Server](http://www.unidata.ucar.edu/software/thred
 
 ## Versions
 
+* `unidata/thredds-docker:4.6.12-SNAPSHOT`
 * `unidata/thredds-docker:4.6.11`
 * `unidata/thredds-docker:4.6.10`
 * `unidata/thredds-docker:4.6.8`


### PR DESCRIPTION
readme update. closes #192.