### PR TITLE
Use /dev/urandom for random numbers

### DIFF
--- a/files/javaopts.sh
+++ b/files/javaopts.sh
@@ -14,6 +14,7 @@ HEADLESS="-Djava.awt.headless=true"
 CONTENT_ROOT="-Dtds.content.root.path=${TDS_CONTENT_ROOT_PATH}"
 JAVA_PREFS_SYSTEM_ROOT="-Djava.util.prefs.systemRoot=$CATALINA_HOME/javaUtilPrefs -Djava.util.prefs.userRoot=$CATALINA_HOME/javaUtilPrefs"
 JNA_DIR="-Djna.tmpdir=/tmp/"
+URAND="-Djava.security.egd=file:/dev/urandom"
 
-JAVA_OPTS="$JAVA_OPTS $CONTENT_ROOT/ $JAVA_PREFS_SYSTEM_ROOT $NORMAL $HEAP_DUMP $HEADLESS $JNA_DIR"
+JAVA_OPTS="$JAVA_OPTS $CONTENT_ROOT/ $JAVA_PREFS_SYSTEM_ROOT $NORMAL $HEAP_DUMP $HEADLESS $JNA_DIR $URAND"
 export JAVA_OPTS


### PR DESCRIPTION
This should dramatically increase startup time on some systems without significantly compromising security ([source](https://www.2uo.de/myths-about-urandom/)).

Closes #172 .