### PR TITLE
Lower healthcheck interval to 10s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,5 +143,5 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["catalina.sh", "run"]
 
-HEALTHCHECK --interval=60s --timeout=3s \
+HEALTHCHECK --interval=10s --timeout=3s \
 	CMD curl --fail 'http://localhost:8080/thredds/catalog.html' || exit 1


### PR DESCRIPTION
With the previous 60s, the container would not be "up" until a minute has passed after starting, even though the application would be ready within 7 seconds (in my setup).

This needlessly delays the process of starting Thredds, specially if it is being proxied by Traefik, which will ignore it until its healthcheck passes.