### PR TITLE
Allow users to set the aws region

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This project contains a `docker-compose` [environment file](https://docs.docker.
     | TDS HOST                    | TDS_HOST              | http://thredds.yourhost.net/ |
     | TDM JVM Max Heap Size (xmx) | TDM_XMX_SIZE          | 6G                           |
     | TDM JVM Min Heap Size (xms) | TDM_XMS_SIZE          | 1G                           |
+    | AWS Region code             | AWS_REGION            | Not set                      |
 
 If you wish to update your configuration, you can either update the `compose.env` file or create your own environments file by copying `compose.env`. If using your own file, you can export the suffix of the file name into an environment variable named `THREDDS_COMPOSE_ENV_LOCAL`.
 
@@ -90,6 +91,8 @@ export THREDDS_COMPOSE_ENV_LOCAL=_local
 < edit compose_local.env >
 docker-compose up thredds-production
 ```
+
+The AWS Region code needs to be set if you are running in AWS and using an IAM policy attached to an EC2 instance to manage access to other AWS resources, such as datasets stored in S3. For possible code values, please see the [AWS service endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html) documentation.
 
 ## `docker-swarm`
 

--- a/files/javaopts.sh
+++ b/files/javaopts.sh
@@ -15,5 +15,8 @@ CONTENT_ROOT="-Dtds.content.root.path=${TDS_CONTENT_ROOT_PATH}"
 JAVA_PREFS_SYSTEM_ROOT="-Djava.util.prefs.systemRoot=$CATALINA_HOME/javaUtilPrefs -Djava.util.prefs.userRoot=$CATALINA_HOME/javaUtilPrefs"
 JNA_DIR="-Djna.tmpdir=/tmp/"
 
-JAVA_OPTS="$JAVA_OPTS $CONTENT_ROOT/ $JAVA_PREFS_SYSTEM_ROOT $NORMAL $HEAP_DUMP $HEADLESS $JNA_DIR"
+# Propagate optional AWS_REGION environment variable to Java system property
+[ -z "${AWS_REGION}" ] && AWS_REGION_PROP="" || AWS_REGION_PROP="-Daws.region=${AWS_REGION}"
+
+JAVA_OPTS="$JAVA_OPTS $CONTENT_ROOT/ $JAVA_PREFS_SYSTEM_ROOT $NORMAL $HEAP_DUMP $HEADLESS $JNA_DIR $AWS_REGION_PROP"
 export JAVA_OPTS


### PR DESCRIPTION
For instances of the TDS relying on IAM profiles attached to EC2 instances in AWS, it's important for the TDS to know about the region is operating within. This can be done through the use of a Java System Property. This PR enables users to set an environment variable within their `compose.env` file, the value of which gets set as a Java System Property on startup of Tomcat.