### PR TITLE
Add back thredds iso plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV TDS_CONTENT_ROOT_PATH /usr/local/tomcat/content
 ENV THREDDS_XMX_SIZE 4G
 ENV THREDDS_XMS_SIZE 4G
 ENV THREDDS_WAR_URL https://downloads.unidata.ucar.edu/tds/5.5/thredds-5.5-SNAPSHOT.war
+ENV THREDDS_ISO_JAR_URL https://downloads.unidata.ucar.edu/tds/5.5/tds-plugin-2.4.6-SNAPSHOT-jar-with-dependencies.jar
 
 COPY files/threddsConfig.xml ${CATALINA_HOME}/content/thredds/threddsConfig.xml
 COPY files/tomcat-users.xml ${CATALINA_HOME}/conf/tomcat-users.xml
@@ -57,7 +58,9 @@ RUN apt-get update && \
     rm -f thredds.war && \
     mkdir -p ${CATALINA_HOME}/content/thredds && \
     chmod 755 ${CATALINA_HOME}/bin/*.sh && \
-    mkdir -p ${CATALINA_HOME}/javaUtilPrefs/.systemPrefs
+    mkdir -p ${CATALINA_HOME}/javaUtilPrefs/.systemPrefs && \
+    # threddsIso
+    curl -fsL "${THREDDS_ISO_JAR_URL}" -o ${CATALINA_HOME}/webapps/thredds/WEB-INF/lib/tds-plugin-jar-with-dependencies.jar
 
 EXPOSE 8080 8443
 


### PR DESCRIPTION
Last week, we removed the thredds iso plugin from the TDS war file, so the most recent TDS-5.5-SNAPSHOTs no longer contain this. The plugin provides the ISO services (iso, ncml, uddc). The reason we removed it was that it created a circular dendency in our build process, that made releases very difficult. As users may be expecting these services, it seems reasonable to keep providing it in our docker image. This is as simple as downloading the tds plugin jar file and placing it in the correct location before starting the TDS. Additionally, the services need to be allowed, but that is already done in the thredds-docker `threddsConfig.xml` file.